### PR TITLE
Updates for local testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,30 +6,58 @@ Learn about [Fastly Compute with Fanout](https://www.fastly.com/documentation/gu
 
 **For more details about this and other starter kits for Compute, see the [Fastly Documentation Hub](https://www.fastly.com/documentation/solutions/starters/)**.
 
-## Setup
+## Local testing
+
+To test Fanout features in the local testing environment, first obtain [Pushpin](https://pushpin.org), the open-source GRIP proxy server that Fastly Fanout is based upon, and make sure it is available on the system path.
+
+Create a Fastly Compute project based on this starter kit.
+
+```term
+mkdir my-fanout-project
+cd my-fanout-project
+fastly compute init --from=https://github.com/fastly/compute-starter-kit-go-fanout-forward
+```
+
+The `fastly.toml` file included in this starter kit includes a `local_server.pushpin` section:
+```toml
+[local_server.pushpin]
+enable = true
+```
+
+It also sets the backend named `"origin"` to `localhost:3000`.
+
+Run the starter kit:
+```term
+fastly compute serve
+```
+
+The Fastly CLI starts Pushpin and then starts the starter kit app at http://localhost:7676/.
+
+On the local testing environment, data can be sent to the connections via the GRIP publish endpoint at `http://localhost:5561/publish/`.
+
+> **IMPORTANT:** Specifying remote backends when testing Fanout handoff in the local development environment is valid. However, because the publishing API runs locally, it is often convenient to also locally run any backends or applications that need to test publishing.
+
+## Running the application on Fastly
 
 The app expects a configured backend named "origin" that points to an origin server. For example, if the server is available at domain `example.com`, then you'll need to create a backend on your Compute service named "origin" with the destination host set to `example.com` and port `443`. Also set `Override Host` to the same host value.
 
-You'll also need to [enable Fanout](https://www.fastly.com/documentation/guides/concepts/real-time-messaging/fanout/#enable-fanout) on your Fastly service to run this application. To enable Fanout on your service, type:
+You'll also need to [enable Fanout](https://www.fastly.com/documentation/guides/concepts/real-time-messaging/fanout/#enable-fanout) on your Fastly service to run this application. After deploying the app, you can enable Fanout on your service, type:
 
 ```shell
 fastly products --enable=fanout
 ```
 
-> [!NOTE]
-> This app is not currently supported in Fastly's [local development server](https://www.fastly.com/documentation/guides/compute/testing/#running-a-local-testing-server), as the development server does not support Fanout features. To experiment with Fanout, you will need to publish this project to your Fastly Compute service. using the `fastly compute publish` command.
+After setting up the backend configuration and enabling Fanout, incoming HTTP and WebSocket requests that arrive at the service will be processed by the fetch handler:
 
-## Running the application
+   1. WebSocket connections will be handed off to Fanout to reach the backend server. Fanout maintains a long-lived connection with the client, and uses the [WebSocket-over-HTTP protocol](https://pushpin.org/docs/protocols/websocket-over-http/) to transform the messages to and from the backend server.
 
-After deploying the app and setting up the backend configuration, incoming HTTP and WebSocket requests that arrive at the service will be processed by the fetch handler:
+   2. HTTP GET and HEAD requests will be handed off to Fanout to reach the backend server. The backend can include [GRIP control messages](https://pushpin.org/docs/protocols/grip/) in its response, instructing Fanout to maintain a long-lived connection with the client.
 
-1. WebSocket connections will be handed off to Fanout to reach the backend server. Fanout maintains a long-lived connection with the client, and uses the [WebSocket-over-HTTP protocol](https://pushpin.org/docs/protocols/websocket-over-http/) to transform the messages to and from the backend server.
-
-2. HTTP GET and HEAD requests will be handed off to Fanout to reach the backend server. The backend can include [GRIP control messages](https://pushpin.org/docs/protocols/grip/) in its response, instructing Fanout to maintain a long-lived connection with the client.
+The GRIP publish endpoint is at `https://api.fastly.com/service/{service-id}/publish/`.
 
 ## Next Steps
 
-The starter kit is written to send all WebSocket and HTTP GET (and HEAD) traffic to Fanout. In an actual app we would be selective about which requests are handed off to Fanout, because requests that are handed off to Fanout do not pass through the Fastly cache.
+The starter kit is written to send hand off all WebSocket and HTTP GET (and HEAD) traffic through Fanout. In an actual app we would be selective about which requests are handed off through Fanout, because requests that are handed off through Fanout do not pass through the Fastly cache.
 
 For details, see [What to hand off to Fanout](https://www.fastly.com/documentation/guides/concepts/real-time-messaging/fanout/#what-to-hand-off-to-fanout) in the Developer Documentation.
 

--- a/fastly.toml
+++ b/fastly.toml
@@ -7,7 +7,15 @@ language = "go"
 manifest_version = 3
 name = "Fanout forwarding starter kit for Go"
 
+[local_server.pushpin]
+enable = true
+
+[local_server.backends]
+[local_server.backends.origin]
+url = "http://localhost:3000/"
+override_host = "localhost:3000"
+
 [scripts]
-  build = "go build -o bin/main.wasm ."
-  env_vars = ["GOARCH=wasm", "GOOS=wasip1"]
-  post_init = "go get github.com/fastly/compute-sdk-go@latest"
+build = "go build -o bin/main.wasm ."
+env_vars = ["GOARCH=wasm", "GOOS=wasip1"]
+post_init = "go get github.com/fastly/compute-sdk-go@latest"


### PR DESCRIPTION
This PR updates the starter kit (mainly the README and fastly.toml files) to prepare for local testing, when it becomes available in the Fastly CLI and Viceroy.

A local installation of Pushpin will be needed and available on the system path to use this feature.