### PR TITLE
Update starter kit for CLI 15.2 and automatic enabling of fanout product

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,17 @@ On the local testing environment, data can be sent to the connections via the GR
 
 The app expects a configured backend named "origin" that points to an origin server. For example, if the server is available at domain `example.com`, then you'll need to create a backend on your Compute service named "origin" with the destination host set to `example.com` and port `443`. Also set `Override Host` to the same host value.
 
-You'll also need to [enable Fanout](https://www.fastly.com/documentation/guides/concepts/real-time-messaging/fanout/#enable-fanout) on your Fastly service to run this application. After deploying the app, you can enable Fanout on your service, type:
+### Enabling Fanout
+
+The first time this starter kit is deployed to your service, Fanout is enabled automatically.
+
+To [enable Fanout](https://www.fastly.com/documentation/guides/concepts/real-time-messaging/fanout/#enable-fanout) support after the fact to an existing Fastly service, type:
 
 ```shell
 fastly products --enable=fanout
 ```
+
+### Handling requests
 
 After setting up the backend configuration and enabling Fanout, incoming HTTP and WebSocket requests that arrive at the service will be processed by the fetch handler:
 
@@ -70,6 +76,11 @@ For example, to check the request for the existence of a certain header:
     useFanout = true
   }
 ```
+
+## Compatibility
+
+- [Fastly CLI](https://www.fastly.com/documentation/reference/tools/cli/) 15.2.0 or newer
+- [Fastly Local Development Server (Viceroy)](https://www.fastly.com/documentation/guides/compute/developer-guides/testing/#running-a-local-testing-server) 0.18.0 or newer
 
 ## Security issues
 

--- a/fastly.toml
+++ b/fastly.toml
@@ -15,6 +15,13 @@ enable = true
 url = "http://localhost:3000/"
 override_host = "localhost:3000"
 
+[setup.backends]
+[setup.backends.origin]
+
+[setup.products]
+[setup.products.fanout]
+enable = true
+
 [scripts]
 build = "go build -o bin/main.wasm ."
 env_vars = ["GOARCH=wasm", "GOOS=wasip1"]


### PR DESCRIPTION
This PR updates the starter kit to improve user experience:

- Adds setup for the Fanout product as well as backend as they will be needed in the actual service
- Makes README text consistent with this starter kit in other languages as well as the WebSocket passthrough starter kit regarding enabling the product
